### PR TITLE
CP-35523: Block access to the website on port 80

### DIFF
--- a/ocaml/alerts/certificate/certificate_check.ml
+++ b/ocaml/alerts/certificate/certificate_check.ml
@@ -62,7 +62,6 @@ let execute rpc session existing_messages (host, alert) =
         || record.API.message_priority <> priority
       in
       let outdated, current = List.partition is_outdated messages_in_host in
-
       List.iter
         (fun (self, _) -> XenAPI.Message.destroy rpc session self)
         outdated ;

--- a/ocaml/gencert/lib.ml
+++ b/ocaml/gencert/lib.ml
@@ -98,7 +98,8 @@ let validate_private_key pkcs8_private_key =
                ] )
          else (
            D.info {|Failed to validate private key because "%s"|} err_msg ;
-           `Msg (server_certificate_key_invalid, [])))
+           `Msg (server_certificate_key_invalid, [])
+         ))
   >>= ensure_key_length
 
 let validate_certificate kind pem now private_key =
@@ -137,8 +138,8 @@ let validate_certificate kind pem now private_key =
   | Leaf ->
       X509.Certificate.decode_pem raw_pem
       |> R.reword_error (fun (`Msg err_msg) ->
-          D.info {|Failed to validate certificate because "%s"|} err_msg ;
-          `Msg (server_certificate_invalid, []))
+             D.info {|Failed to validate certificate because "%s"|} err_msg ;
+             `Msg (server_certificate_invalid, []))
       >>= ensure_keys_match private_key
       >>= ensure_validity ~time:now
       >>= ensure_sha256_signature_algorithm

--- a/ocaml/xapi/fileserver.ml
+++ b/ocaml/xapi/fileserver.ml
@@ -81,40 +81,43 @@ let response_file s file_path =
   in
   Http_svr.response_file ~mime_content_type s file_path
 
+let access_forbidden req s =
+  (* Reject external non-TLS requests (depending on config) *)
+  !Xapi_globs.website_https_only
+  && (not (Context.is_unix_socket s))
+  && Context._client_of_rq req = None
+
 let send_file (uri_base : string) (dir : string) (req : Request.t)
     (bio : Buf_io.t) _ =
   let uri_base_len = String.length uri_base in
   let s = Buf_io.fd_of bio in
   Buf_io.assert_buffer_empty bio ;
-  match Context._client_of_rq req with
-  | None when !Xapi_globs.website_https_only ->
-      (* Reject non-TLS requests *)
-      Http_svr.response_forbidden ~req s
-  | _ -> (
-      let uri = req.Request.uri in
-      try
-        let relative_url =
-          String.sub uri uri_base_len (String.length uri - uri_base_len)
-        in
-        (* file_path is the thing which should be served *)
-        let file_path = dir ^ "/" ^ relative_url in
-        (* remove any dodgy use of "." or ".." NB we don't prevent the use of symlinks *)
+  if access_forbidden req s then
+    Http_svr.response_forbidden ~req s
+  else
+    let uri = req.Request.uri in
+    try
+      let relative_url =
+        String.sub uri uri_base_len (String.length uri - uri_base_len)
+      in
+      (* file_path is the thing which should be served *)
+      let file_path = dir ^ "/" ^ relative_url in
+      (* remove any dodgy use of "." or ".." NB we don't prevent the use of symlinks *)
+      let file_path =
+        Xapi_stdext_unix.Unixext.resolve_dot_and_dotdot file_path
+      in
+      if not (String.startswith dir file_path) then (
+        debug "Rejecting request for file: %s (outside of directory %s)"
+          file_path dir ;
+        Http_svr.response_forbidden ~req s
+      ) else
+        let stat = Unix.stat file_path in
+        (* if a directory, automatically add index.html *)
         let file_path =
-          Xapi_stdext_unix.Unixext.resolve_dot_and_dotdot file_path
+          if stat.Unix.st_kind = Unix.S_DIR then
+            file_path ^ "/index.html"
+          else
+            file_path
         in
-        if not (String.startswith dir file_path) then (
-          debug "Rejecting request for file: %s (outside of directory %s)"
-            file_path dir ;
-          Http_svr.response_forbidden ~req s
-        ) else
-          let stat = Unix.stat file_path in
-          (* if a directory, automatically add index.html *)
-          let file_path =
-            if stat.Unix.st_kind = Unix.S_DIR then
-              file_path ^ "/index.html"
-            else
-              file_path
-          in
-          response_file s file_path
-      with _ -> Http_svr.response_missing s (missing uri)
-    )
+        response_file s file_path
+    with _ -> Http_svr.response_missing s (missing uri)

--- a/ocaml/xapi/fileserver.ml
+++ b/ocaml/xapi/fileserver.ml
@@ -86,27 +86,35 @@ let send_file (uri_base : string) (dir : string) (req : Request.t)
   let uri_base_len = String.length uri_base in
   let s = Buf_io.fd_of bio in
   Buf_io.assert_buffer_empty bio ;
-  let uri = req.Request.uri in
-  try
-    let relative_url =
-      String.sub uri uri_base_len (String.length uri - uri_base_len)
-    in
-    (* file_path is the thing which should be served *)
-    let file_path = dir ^ "/" ^ relative_url in
-    (* remove any dodgy use of "." or ".." NB we don't prevent the use of symlinks *)
-    let file_path = Stdext.Unixext.resolve_dot_and_dotdot file_path in
-    if not (String.startswith dir file_path) then (
-      debug "Rejecting request for file: %s (outside of directory %s)" file_path
-        dir ;
+  match Context._client_of_rq req with
+  | None when !Xapi_globs.website_https_only ->
+      (* Reject non-TLS requests *)
       Http_svr.response_forbidden ~req s
-    ) else
-      let stat = Unix.stat file_path in
-      (* if a directory, automatically add index.html *)
-      let file_path =
-        if stat.Unix.st_kind = Unix.S_DIR then
-          file_path ^ "/index.html"
-        else
-          file_path
-      in
-      response_file s file_path
-  with _ -> Http_svr.response_missing s (missing uri)
+  | _ -> (
+      let uri = req.Request.uri in
+      try
+        let relative_url =
+          String.sub uri uri_base_len (String.length uri - uri_base_len)
+        in
+        (* file_path is the thing which should be served *)
+        let file_path = dir ^ "/" ^ relative_url in
+        (* remove any dodgy use of "." or ".." NB we don't prevent the use of symlinks *)
+        let file_path =
+          Xapi_stdext_unix.Unixext.resolve_dot_and_dotdot file_path
+        in
+        if not (String.startswith dir file_path) then (
+          debug "Rejecting request for file: %s (outside of directory %s)"
+            file_path dir ;
+          Http_svr.response_forbidden ~req s
+        ) else
+          let stat = Unix.stat file_path in
+          (* if a directory, automatically add index.html *)
+          let file_path =
+            if stat.Unix.st_kind = Unix.S_DIR then
+              file_path ^ "/index.html"
+            else
+              file_path
+          in
+          response_file s file_path
+      with _ -> Http_svr.response_missing s (missing uri)
+    )

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -776,6 +776,8 @@ let sm_dir = ref "/opt/xensource/sm"
 
 let web_dir = ref "/opt/xensource/www"
 
+let website_https_only = ref true
+
 let cluster_stack_root = ref "/usr/libexec/xapi/cluster-stack"
 
 let cluster_stack_default = ref "xhad"
@@ -1118,6 +1120,10 @@ let other_options =
     , Arg.Set create_tools_sr
     , (fun () -> string_of_bool !create_tools_sr)
     , "Indicates whether to create an SR for Tools ISOs" )
+  ; ( "website-https-only"
+    , Arg.Set website_https_only
+    , (fun () -> string_of_bool !website_https_only)
+    , "Allow access to the internal website using HTTPS only (no HTTP)" )
   ]
 
 let all_options = options_of_xapi_globs_spec @ other_options

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -380,7 +380,7 @@ let check_operation_error ~__context ?(sr_records = []) ?(pbd_records = [])
                       None
                 | `snapshot when record.Db_actions.vDI_sharable ->
                     Some (Api_errors.vdi_is_sharable, [_ref])
-                | `snapshot | `copy when reset_on_boot ->
+                | (`snapshot | `copy) when reset_on_boot ->
                     Some
                       ( Api_errors.vdi_on_boot_mode_incompatible_with_operation
                       , [] )


### PR DESCRIPTION
By default, only HTTPS is allowed, as a small step to improve security.
This only affects the web content on the GET / handler (for the time
being).  There is a config file option to re-enable HTTP access if
required.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>
(cherry picked from commit 19ecafab18d8e7658e0f347c539b571c2dd28bd3)